### PR TITLE
lib: otdoa_al: force config dl in ubsa request

### DIFF
--- a/include/otdoa_al/otdoa_api.h
+++ b/include/otdoa_al/otdoa_api.h
@@ -207,18 +207,25 @@ typedef struct {
  * API call.
  */
 typedef struct {
+	/** 28bit cell id. */
+	uint32_t ecgi;
+
 	/** PLMN ID.
 	 *
 	 * Bytes encoded as follows:
 	 *     mcc2_mcc1, mnc3_mcc3, mnc2_mnc1
 	 */
 	uint8_t plmn[3];
-	/** 28bit cell id. */
-	uint32_t ecgi;
+
+	/** Force a download of a new config file along with the uBSA */
+	bool config_dl;
+
 	/** Mobile Country Code. Range: 0...999. */
 	uint16_t mcc;
+
 	/** Mobile Network Code. Range: 0...999. */
 	uint16_t mnc;
+
 	/** Cell PCI. Range: 0...503. */
 	uint16_t pci;
 

--- a/lib/otdoa_al/otdoa_http_api.c
+++ b/lib/otdoa_al/otdoa_http_api.c
@@ -112,6 +112,15 @@ int32_t otdoa_api_ubsa_download(const otdoa_api_ubsa_dl_req_t *p_dl_request,
 			return rc;
 		}
 	}
+
+	/* if a config file download is being forced, get that first */
+	if (p_dl_request->config_dl) {
+		rc = otdoa_api_cfg_download();
+		if (rc != OTDOA_API_SUCCESS) {
+			return rc;
+		}
+	}
+
 	/* Send the request message */
 	tOTDOA_MSG_HTTP_GET_UBSA msg = { 0 };
 


### PR DESCRIPTION
Adds a parameter to ubsa download requests to force a config file download along with it