### PR TITLE
PHYW-498 Log Updates

### DIFF
--- a/lib/otdoa_al/otdoa_fs.c
+++ b/lib/otdoa_al/otdoa_fs.c
@@ -134,7 +134,6 @@ tOFS_FILE *ofs_fopen(const char *path, const char *psz_mode)
 		int iFS = fs_stat(path, &deFile);
 
 		if (0 == iFS) {
-			printk("ofs_fopen(\"%s\",\"%s\") unlink existing file\n", path, psz_mode);
 			fs_unlink(path);
 		}
 	}

--- a/lib/otdoa_al/otdoa_nordic_at.c
+++ b/lib/otdoa_al/otdoa_nordic_at.c
@@ -252,9 +252,9 @@ error_exit:
 	if (i_ret != 0
 		&& i_ret != OTDOA_EVENT_FAIL_NO_DLEARFCN && i_ret != OTDOA_EVENT_FAIL_NO_PCI) {
 		if (psz_resp) {
-			LOG_ERR("AT%%XMONITOR response %s", psz_resp);
+			LOG_WRN("AT%%XMONITOR response %s", psz_resp);
 		}
-		LOG_ERR("Failed to parse AT%%XMONITOR response.  returning %d\n", i_ret);
+		LOG_WRN("Failed to parse AT%%XMONITOR response.  returning %d\n", i_ret);
 	} else {
 		LOG_DBG("otdoa_nordic_at_parse_xmonitor_response: ECGI=%" PRIu32
 			      " (0x%08X), DLEARFCN=%" PRIu32 " returning %d\n",
@@ -273,7 +273,7 @@ int otdoa_nordic_at_get_xmonitor(otdoa_xmonitor_params_t *params)
 	memset(monitor_buf, 0, sizeof(monitor_buf));
 	i_ret = nrf_modem_at_cmd(monitor_buf, sizeof(monitor_buf), "AT%%XMONITOR");
 	if (i_ret) {
-		LOG_ERR("otdoa_nordic_at_get_xmonitor: ERROR (%d) Failed to get "
+		LOG_WRN("otdoa_nordic_at_get_xmonitor: ERROR (%d) Failed to get "
 			      "MODEM Status\n",
 			      i_ret);
 		i_ret = OTDOA_EVENT_FAIL_BAD_MODEM_RESP;
@@ -343,12 +343,12 @@ int otdoa_nordic_at_get_imei_from_modem(void)
 		len = NRF_IMEI_LEN;
 	}
 	strncpy((char *)otdoa_nordic_at_imei, p_imei_token, len);
-	LOG_INF("Got IMEI %s\n", otdoa_nordic_at_imei);
+	LOG_INF("Got IMEI %s", otdoa_nordic_at_imei);
 
 	return 0;
 
 error_return:
-	LOG_ERR("otdoa_nordic_at_get_imei_from_modem() invalid response %s", imei_buf);
+	LOG_WRN("otdoa_nordic_at_get_imei_from_modem() invalid response %s", imei_buf);
 	return OTDOA_EVENT_FAIL_BAD_MODEM_RESP;
 }
 

--- a/lib/otdoa_al/otdoa_thread_http.c
+++ b/lib/otdoa_al/otdoa_thread_http.c
@@ -88,14 +88,14 @@ int tls_setup(int fd, const char *host)
 
 	nErr = setsockopt(fd, SOL_TLS, TLS_PEER_VERIFY, &verify, sizeof(verify));
 	if (nErr) {
-		LOG_ERR("Failed to setup peer verification: %s", strerror(errno));
+		LOG_WRN("Failed to setup peer verification: %s", strerror(errno));
 		return nErr;
 	}
 
 	/* associate the socket with the security tag we have provisioned the certificate with */
 	nErr = setsockopt(fd, SOL_TLS, TLS_SEC_TAG_LIST, tls_sec_tag, sizeof(tls_sec_tag));
 	if (nErr) {
-		LOG_ERR("Failed to setup TLS sec tag: %s", strerror(errno));
+		LOG_WRN("Failed to setup TLS sec tag: %s", strerror(errno));
 		return nErr;
 	}
 
@@ -108,7 +108,7 @@ int tls_setup(int fd, const char *host)
 	LOG_INF("tls_setup(%d, %s)", fd, server);
 	nErr = setsockopt(fd, SOL_TLS, TLS_HOSTNAME, server, strlen(server) + 1);
 	if (nErr) {
-		LOG_ERR("Failed to setup TLS Hostname: %s", strerror(errno));
+		LOG_WRN("Failed to setup TLS Hostname: %s", strerror(errno));
 		return nErr;
 	}
 
@@ -157,7 +157,7 @@ int otdoa_http_bind(struct addrinfo **res, const char *pURL, bool bDisableTls,
 		k_sleep(K_SECONDS(1));
 	}
 	if (nRetry >= MAX_BIND_RETRIES) {
-		LOG_ERR("getaddrinfo() retry %d failed, err: %s", nRetry,
+		LOG_WRN("getaddrinfo() retry %d failed, err: %s", nRetry,
 			      rc == EAI_SYSTEM ? strerror(errno) : gai_strerror(rc));
 		return -1;
 	}
@@ -217,7 +217,7 @@ int otdoa_http_connect(int *fdSocket, struct sockaddr *res, char *szModemAddress
 	LOG_INF("HTTP connect on protocol %d", proto);
 	*fdSocket = socket(AF_INET, SOCK_STREAM, proto);
 	if (*fdSocket == -1) {
-		LOG_ERR("failed to open socket");
+		LOG_WRN("failed to open socket");
 		return -1;
 	}
 
@@ -234,7 +234,7 @@ int otdoa_http_connect(int *fdSocket, struct sockaddr *res, char *szModemAddress
 	if (bFound) {
 		LOG_DBG("nrf9161 IP address %s", szModemAddress);
 	} else {
-		LOG_ERR("failed to get IP address\r\n");
+		LOG_WRN("failed to get IP address\r\n");
 		return -1;
 	}
 #endif
@@ -254,8 +254,8 @@ int otdoa_http_connect(int *fdSocket, struct sockaddr *res, char *szModemAddress
 	LOG_DBG("connect() on socket %d", *fdSocket);
 	nErr = connect(*fdSocket, res, sizeof(struct sockaddr_in));
 	if (nErr) {
-		LOG_ERR("connect failed: nErr = %d, %d -> %s", nErr, errno, strerror(errno));
-		LOG_ERR("connect failed: fdSocket = %d, ai_addr = %p", *fdSocket, (void *)res);
+		LOG_WRN("connect failed: nErr = %d, %d -> %s", nErr, errno, strerror(errno));
+		LOG_WRN("connect failed: fdSocket = %d, ai_addr = %p", *fdSocket, (void *)res);
 		otdoa_http_disconnect(fdSocket);
 		return -3;
 	}


### PR DESCRIPTION
Cleaned up logs to remove unneeded CR/LF characters. 
Changes the log level on recoverable errors to WRN.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Downgrades several error logs to warnings and removes stray newlines/verbose prints across Nordic AT, HTTP, and FS modules.
> 
> - **Logging**
>   - **Nordic AT (`lib/otdoa_al/otdoa_nordic_at.c`)**:
>     - Downgrade multiple `LOG_ERR` messages to `LOG_WRN` for recoverable cases (XMONITOR parse/get, IMEI invalid response).
>     - Remove trailing newline from IMEI info log.
>   - **HTTP (`lib/otdoa_al/otdoa_thread_http.c`)**:
>     - Downgrade several failures to warnings (`setsockopt` for TLS options, `getaddrinfo` retry failure, socket open, IP acquisition, `connect` failures).
>     - Keep critical failures as errors (e.g., `tls_setup` failure).
>   - **FS (`lib/otdoa_al/otdoa_fs.c`)**:
>     - Remove verbose `printk` when unlinking existing file in `ofs_fopen()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 310570af2d08b1cfdd3b3abe4bfeb9fbea2064d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->