### PR TITLE
lib: otdoa_lib: Fix compile issues with CONFIG_LOG

### DIFF
--- a/lib/otdoa_al/otdoa_http_api.c
+++ b/lib/otdoa_al/otdoa_http_api.c
@@ -26,7 +26,10 @@ int32_t otdoa_al_init(otdoa_api_callback_t event_callback)
 {
 	otdoa_http_register_callback(event_callback);
 	otdoa_http_init();
+
+#if CONFIG_LOG
 	otdoa_log_init();
+#endif /* CONFIG_LOG */
 
 #if CONFIG_OTDOA_API_TLS_CERT_INSTALL
 	bool exists;

--- a/lib/otdoa_al/otdoa_log.c
+++ b/lib/otdoa_al/otdoa_log.c
@@ -32,6 +32,8 @@ LOG_MODULE_REGISTER(otdoa, LOG_LEVEL_DBG);
 
 uint32_t otdoa_log_level_set(int level, const char *backend)
 {
+#if CONFIG_LOG
+
 	int source_id = log_source_id_get("otdoa");
 
 	if (source_id >= 0) {
@@ -39,11 +41,13 @@ uint32_t otdoa_log_level_set(int level, const char *backend)
 	} else {
 		LOG_WRN("otdoa_log_level_set(): Failed to find module otdoa");
 	}
+#endif /* CONFIG_LOG */
 	return 0;
 }
 
 void otdoa_log(int log_level, const char *string)
 {
+#if CONFIG_LOG
 	switch (log_level) {
 	case LOG_LEVEL_ERR:
 		LOG_ERR("%s", string);
@@ -61,6 +65,8 @@ void otdoa_log(int log_level, const char *string)
 		/* ignore the log */
 		break;
 	}
+#endif /* CONFIG_LOG */
+
 }
 
 void otdoa_log_init(void)


### PR DESCRIPTION
Fixes some compilation failures if the project
set CONFIG_LOG=n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Wrap log initialization and logging internals with CONFIG_LOG to avoid build failures when logging is disabled.
> 
> - **Logging guards**:
>   - `lib/otdoa_al/otdoa_http_api.c`: Call `otdoa_log_init()` only when `CONFIG_LOG` is enabled.
>   - `lib/otdoa_al/otdoa_log.c`:
>     - Execute `otdoa_log_level_set()` logic only under `CONFIG_LOG`.
>     - Execute `otdoa_log()` switch/logging only under `CONFIG_LOG`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dbf84077662e6a5bc22cb48e84f16ac2ec50cf1f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->