### PR TITLE
samples: cellular: otdoa: Set console to 115200 baud

### DIFF
--- a/samples/cellular/otdoa/README.rst
+++ b/samples/cellular/otdoa/README.rst
@@ -53,7 +53,7 @@ Running the sample application
 |test_sample|
 
 #. |connect_kit|
-#. |connect_terminal|  The terminal application should be set for 921600 baud for this sample.
+#. |connect_terminal|  The terminal application should be set for 115200 baud for this sample.
 #. Power on or reset your device
 #. Observe that the sample starts and connects to the LTE network
 #. Enter 'phywi' on the terminal and verify that the phywi shell command help is displayed.

--- a/samples/cellular/otdoa/boards/nrf9151dk_nrf9151_ns.overlay
+++ b/samples/cellular/otdoa/boards/nrf9151dk_nrf9151_ns.overlay
@@ -58,7 +58,7 @@
 
 &uart0 {
 	status = "okay";
-	current-speed = <921600>;
+	current-speed = <115200>;
 };
 
 &uart1 {

--- a/samples/cellular/otdoa/boards/nrf9161dk_nrf9161_ns.overlay
+++ b/samples/cellular/otdoa/boards/nrf9161dk_nrf9161_ns.overlay
@@ -58,7 +58,7 @@
 
 &uart0 {
 	status = "okay";
-	current-speed = <921600>;
+	current-speed = <115200>;
 };
 
 &uart1 {

--- a/samples/cellular/otdoa/boards/nrf9161dk_nrf9161_ns_0_7_0.overlay
+++ b/samples/cellular/otdoa/boards/nrf9161dk_nrf9161_ns_0_7_0.overlay
@@ -61,7 +61,7 @@
 
 &uart0 {
 	status = "okay";
-	current-speed = <921600>;
+	current-speed = <115200>;
 };
 
 &uart1 {

--- a/samples/cellular/otdoa/boards/thingy91x_nrf9151_ns.overlay
+++ b/samples/cellular/otdoa/boards/thingy91x_nrf9151_ns.overlay
@@ -2,8 +2,8 @@
  * Thingy91X board DTS Overlay
  */
 
-/* set console UART to 921600 baud */
+/* set console UART to 115200 baud */
 &uart0 {
 	status = "okay";
-	current-speed = <921600>;
+	current-speed = <115200>;
 };


### PR DESCRIPTION
Changes the baud rate for the UART console to
115200 by default.