### PR TITLE
lib: otdoa_lib: Support 417 error code returned from server

### DIFF
--- a/include/otdoa_al/otdoa_api.h
+++ b/include/otdoa_al/otdoa_api.h
@@ -119,7 +119,7 @@ typedef enum {
 	OTDOA_EVENT_FAIL_HTTP_CONFLICT = 409,
 
 	/** Expectation Failed - server will return this on failure in SSL verify */
-	USER_EVENT_FAIL_HTTP_EXPECT_FAIL = 417,
+	OTDOA_EVENT_FAIL_HTTP_EXPECT_FAIL = 417,
 
 	/** uBSA generation was not possible */
 	OTDOA_EVENT_FAIL_HTTP_UNPROCESSABLE_CONTENT = 422,

--- a/include/otdoa_al/otdoa_api.h
+++ b/include/otdoa_al/otdoa_api.h
@@ -118,6 +118,11 @@ typedef enum {
 	/** User already has a pending uBSA */
 	OTDOA_EVENT_FAIL_HTTP_CONFLICT = 409,
 
+	/** Expectation Failed - server will return this on failure in SSL verify
+	 * UE will retry as a workaround
+	 */
+	USER_EVENT_FAIL_HTTP_EXPECT_FAIL = 417,
+
 	/** uBSA generation was not possible */
 	OTDOA_EVENT_FAIL_HTTP_UNPROCESSABLE_CONTENT = 422,
 

--- a/include/otdoa_al/otdoa_api.h
+++ b/include/otdoa_al/otdoa_api.h
@@ -118,9 +118,7 @@ typedef enum {
 	/** User already has a pending uBSA */
 	OTDOA_EVENT_FAIL_HTTP_CONFLICT = 409,
 
-	/** Expectation Failed - server will return this on failure in SSL verify
-	 * UE will retry as a workaround
-	 */
+	/** Expectation Failed - server will return this on failure in SSL verify */
 	USER_EVENT_FAIL_HTTP_EXPECT_FAIL = 417,
 
 	/** uBSA generation was not possible */


### PR DESCRIPTION
Modifies the HTTP error codes to include 417 Expectation Failed return code.  This code is returned by the server to indicate a failure in the processing of the JWT.  Previously a 500 failure was returned by the server.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Add `OTDOA_EVENT_FAIL_HTTP_EXPECT_FAIL` (HTTP 417) to OTDOA API error codes for SSL verification failures.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3ec983d685b4770a2256fd863b6b99c71093266d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->