### PR TITLE
[PHYW-552] Trace Always Disabled

### DIFF
--- a/lib/otdoa_al/CMakeLists.txt
+++ b/lib/otdoa_al/CMakeLists.txt
@@ -1,4 +1,5 @@
-zephyr_library()
+zephyr_library_get_current_dir_lib_name(${ZEPHYR_BASE} OTDOA_AL_LIB_TARGET_NAME)
+zephyr_library_named(${OTDOA_AL_LIB_TARGET_NAME})
 
 # lfs.h is not in the include path, so add it explicitly here
 zephyr_library_include_directories(${ZEPHYR_BASE}/../modules/fs/littlefs)


### PR DESCRIPTION
Expands the zephyr_library call for the otdoa_al library in order to keep and expose the library target name as a variable for use in other CMake files