### PR TITLE
[PHYW-576] ECID-only estimate

### DIFF
--- a/include/otdoa_al/otdoa_api.h
+++ b/include/otdoa_al/otdoa_api.h
@@ -100,6 +100,9 @@ typedef enum {
 	/** Failed to get PCI from Modem */
 	OTDOA_EVENT_FAIL_NO_PCI = 17,
 
+	/** Failed to get RSRP from Modem */
+	OTDOA_EVENT_FAIL_NO_RSRP = 18,
+
 	/** The uBSA is still being generated */
 	OTDOA_EVENT_HTTP_NOT_READY = 202,
 

--- a/include/otdoa_al/otdoa_nordic_at.h
+++ b/include/otdoa_al/otdoa_nordic_at.h
@@ -54,6 +54,9 @@ typedef struct {
 	 * 9: E-UTRAN NB-S1
 	 */
 	uint16_t act;
+
+	/** RSRP */
+	uint8_t rsrp;
 } otdoa_xmonitor_params_t;
 
 /** @brief Parse the response to AT%%XMONITOR and return ECGI & DLEARFCN

--- a/lib/otdoa_al/otdoa_nordic_at.c
+++ b/lib/otdoa_al/otdoa_nordic_at.c
@@ -208,8 +208,10 @@ int otdoa_nordic_at_parse_xmonitor_response(const char *const psz_resp, size_t u
 		{
 			const int i_scn_rv = sscanf(token, "%"SCNu16, &u16_rsrp);
 
-			if (1 != i_scn_rv || u16_rsrp == 0) {
-				i_ret = 0;
+			/* 97 is the max RSRP the modem should return */
+			if (1 != i_scn_rv || u16_rsrp > 97) {
+				/* failure to parse RSRP is not an error */
+				u16_rsrp = XMONITOR_UNKNOWN_RSRP;
 			}
 			break;
 		}
@@ -269,10 +271,10 @@ error_exit:
 		if (psz_resp) {
 			LOG_WRN("AT%%XMONITOR response %s", psz_resp);
 		}
-		LOG_WRN("Failed to parse AT%%XMONITOR response.  returning %d\n", i_ret);
+		LOG_WRN("Failed to parse AT%%XMONITOR response.  returning %d", i_ret);
 	} else {
 		LOG_DBG("otdoa_nordic_at_parse_xmonitor_response: ECGI=%" PRIu32
-			      " (0x%08X), DLEARFCN=%" PRIu32 " returning %d\n",
+			      " (0x%08X), DLEARFCN=%" PRIu32 " returning %d",
 			      u32_egci, (unsigned int)u32_egci, u32_dlearfcn, i_ret);
 	}
 

--- a/lib/otdoa_al/otdoa_nordic_at.c
+++ b/lib/otdoa_al/otdoa_nordic_at.c
@@ -209,7 +209,7 @@ int otdoa_nordic_at_parse_xmonitor_response(const char *const psz_resp, size_t u
 			const int i_scn_rv = sscanf(token, "%"SCNu16, &u16_rsrp);
 
 			if (1 != i_scn_rv || u16_rsrp == 0) {
-				i_ret = OTDOA_EVENT_FAIL_NO_RSRP;
+				i_ret = 0;
 			}
 			break;
 		}

--- a/lib/otdoa_al/otdoa_nordic_at.c
+++ b/lib/otdoa_al/otdoa_nordic_at.c
@@ -84,6 +84,7 @@ char *otdoa_nordic_at_strtok_r(char *s, char delim, char **save_ptr)
 #define XMONITOR_UNKNOWN_ACT      0xFFFFFFFF
 #define XMONITOR_UNKNOWN_MCC      0xFFFF
 #define XMONITOR_UNKNOWN_MNC      0xFFFF
+#define XMONITOR_UNKNOWN_RSRP     0xFF
 
 /* Parse the response to AT%%XMONITOR and return ECGI & DLEARFCN */
 int otdoa_nordic_at_parse_xmonitor_response(const char *const psz_resp, size_t u_resp_len,
@@ -100,6 +101,7 @@ int otdoa_nordic_at_parse_xmonitor_response(const char *const psz_resp, size_t u
 	uint16_t u16_mcc = XMONITOR_UNKNOWN_MCC;
 	uint16_t u16_mnc = XMONITOR_UNKNOWN_MNC;
 	uint16_t u16_pci = UNKNOWN_UBSA_PCI;
+	uint16_t u16_rsrp = XMONITOR_UNKNOWN_RSRP;
 
 	if (!psz_resp) {
 		LOG_ERR("otdoa_nordic_at_parse_xmonitor_response(): NULL pointer\n");
@@ -202,6 +204,15 @@ int otdoa_nordic_at_parse_xmonitor_response(const char *const psz_resp, size_t u
 			}
 			break;
 		}
+		case 10: /* RSRP */
+		{
+			const int i_scn_rv = sscanf(token, "%"SCNu16, &u16_rsrp);
+
+			if (1 != i_scn_rv || u16_rsrp == 0) {
+				i_ret = OTDOA_EVENT_FAIL_NO_RSRP;
+			}
+			break;
+		}
 		default:
 			break;
 		}
@@ -229,6 +240,7 @@ error_exit:
 			params->mnc = u16_mnc;
 			params->pci = u16_pci;
 			params->reg_status = u32_reg_status;
+			params->rsrp = u16_rsrp;
 		}
 	} else if (OTDOA_EVENT_FAIL_NO_DLEARFCN == i_ret && u32_egci != 0) {
 		/* return the ECGI and default DLEARFCN, and error code indicating no DLEARFCN */
@@ -239,6 +251,7 @@ error_exit:
 		params->mnc = u16_mnc;
 		params->pci = u16_pci;
 		params->reg_status = u32_reg_status;
+		params->rsrp = u16_rsrp;
 	} else if (OTDOA_EVENT_FAIL_NO_PCI == i_ret && u32_egci != 0) {
 		/* return the ECGI and default DLEARFCN, and error code indicating no DLEARFCN */
 		params->ecgi = u32_egci;
@@ -248,6 +261,7 @@ error_exit:
 		params->mnc = u16_mnc;
 		params->pci = UNKNOWN_UBSA_PCI;
 		params->reg_status = u32_reg_status;
+		params->rsrp = u16_rsrp;
 	}
 
 	if (i_ret != 0


### PR DESCRIPTION
Update XMONITOR parsing to grab RSRP. This is needed to compute an ECID estimate without having any RSSI values from capture samples