### PR TITLE
Update OTDOA sample to support results upload to PhyWi cloud

### DIFF
--- a/lib/otdoa_al/otdoa_http.c
+++ b/lib/otdoa_al/otdoa_http.c
@@ -153,7 +153,6 @@ const char *otdoa_http_get_download_url(void)
 	}
 }
 
-#ifdef CONFIG_OTDOA_ENABLE_RESULTS_UPLOAD
 const char *otdoa_http_get_upload_pw(void)
 {
 	return RESULTS_UPLOAD_PW;
@@ -177,4 +176,3 @@ const char *otdoa_http_get_upload_url(void)
 		return UPLOAD_SERVER_URL;
 	}
 }
-#endif

--- a/lib/otdoa_al/otdoa_http.h
+++ b/lib/otdoa_al/otdoa_http.h
@@ -22,6 +22,9 @@
 #ifdef CONFIG_OTDOA_ENABLE_RESULTS_UPLOAD
 #define RESULTS_UPLOAD_PW CONFIG_OTDOA_RESULTS_UPLOAD_PW
 #define UPLOAD_SERVER_URL CONFIG_OTDOA_UPLOAD_SERVER_URL
+#else
+#define RESULTS_UPLOAD_PW "<Request PW from PhyWi>"
+#define UPLOAD_SERVER_URL "<Request URL from PhyWi>"
 #endif
 
 /* set to 1 to have HTTP functions use scratchpad, else use malloc()/free() */

--- a/samples/cellular/otdoa/prj.conf
+++ b/samples/cellular/otdoa/prj.conf
@@ -172,3 +172,6 @@ CONFIG_OTDOA_SHELL_COMMANDS=y
 
 # OTDOA Sample Application
 CONFIG_PERIODIC_EST_INTERVAL=0
+# optionally enable upload of results to PhyWi cloud server
+#CONFIG_OTDOA_ENABLE_RESULTS_UPLOAD=y
+#CONFIG_OTDOA_RESULTS_UPLOAD_PW="<request from PhyWi>"

--- a/samples/cellular/otdoa/src/otdoa_sample_app.c
+++ b/samples/cellular/otdoa/src/otdoa_sample_app.c
@@ -133,10 +133,39 @@ static void otdoa_event_handler(const otdoa_api_event_data_t *p_event_data)
 		LOG_INF("  accuracy: %.01f m", (double)(p_event_data->results.accuracy));
 		display_result_details(&p_event_data->results.details);
 		LOG_INF("OTDOA position estimate SUCCESS");
+
+#ifdef CONFIG_OTDOA_ENABLE_RESULTS_UPLOAD
+		LOG_INF("Uploading results.");
+
+		int res = otdoa_api_upload_results(&p_event_data->results, NULL, NULL, NULL);
+
+		if (res != 0) {
+			LOG_ERR("Upload results failed: %d", res);
+			set_blink_error();
+			pos_est_timer_restart();
+		} else {
+			LOG_INF("Results upload started");
+		}
+#else
 		set_blink_sleep();
+		pos_est_timer_restart();
+#endif
+		break;
+	}
+
+#ifdef CONFIG_OTDOA_ENABLE_RESULTS_UPLOAD
+	case OTDOA_EVENT_RESULTS_UL_COMPL:
+	{
+		LOG_INF("OTDOA_EVENT_RESULTS_UL_COMPL: status: %d", p_event_data->ul_compl.status);
+		if (p_event_data->ul_compl.status != 0) {
+			set_blink_error();
+		} else {
+			set_blink_sleep();
+		}
 		pos_est_timer_restart();
 		break;
 	}
+#endif
 
 	case OTDOA_EVENT_FAIL: {
 		LOG_ERR("OTDOA_EVENT_FAIL:  failure code = %d", p_event_data->failure_code);


### PR DESCRIPTION
Fixes support for results upload in OTDOA sample application (if enabled).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are gated behind Kconfig in the sample and only affect post-estimate behavior and HTTP symbol availability; no auth or core positioning logic changes when upload stays disabled.
> 
> **Overview**
> **Enables optional upload of OTDOA position results to the PhyWi cloud** when `CONFIG_OTDOA_ENABLE_RESULTS_UPLOAD` is set in the cellular OTDOA sample.
> 
> On success, the sample calls `otdoa_api_upload_results()` instead of immediately entering sleep/restarting the periodic timer; it handles `OTDOA_EVENT_RESULTS_UL_COMPL` to set LED state and restart the timer after upload finishes. Upload start failures are logged and treated like other errors.
> 
> The HTTP layer always exposes upload URL/password helpers: compile-time `#ifdef` guards around those functions in `otdoa_http.c` are removed, and when upload is disabled at build time `otdoa_http.h` supplies placeholder `RESULTS_UPLOAD_PW` / `UPLOAD_SERVER_URL` strings. `prj.conf` documents the optional Kconfig toggles (commented out by default).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e3e2b3184a367c9be6855b4c70a1e6cdb3291b1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->